### PR TITLE
Make inactive modeline foreground dimmer

### DIFF
--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -122,7 +122,7 @@
                         '(mode-line-inactive
                           ((((class color)
                              (min-colors 89))
-                            (:background "#1B2224" :foreground "#C5C8C9"))))
+                            (:background "#1B2224" :foreground "#62686A"))))
                         '(mode-line-buffer-id
                           ((((class color)
                              (min-colors 89))


### PR DESCRIPTION
The updated color matches the comment color

This matches the behavior of many themes I've used which makes it easy to tell which window is active by dimming the modeline of inactive windows. Without this or something like it, it's difficult to tell which window is active.

![out](https://user-images.githubusercontent.com/15976214/147584201-13fe458c-50b2-4d51-b969-5ba4a7d17934.png)
