### PR TITLE
Set explicit fringe background color

### DIFF
--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -132,7 +132,7 @@ Also bind `class' to ((class color) (min-colors 89))."
                           `(mode-line-inactive ((t (:background ,uwu-black :foreground ,uwu-comment))))
                           `(mode-line-buffer-id ((t (:weight bold :background ,uwu-black :foreground ,uwu-bright-white))))
                           `(mode-line ((t (:weight bold :background ,uwu-black :foreground ,uwu-bright-white))))
-                          `(fringe ((t (:underline t :foreground ,uwu-highlight))))
+                          `(fringe ((t (:underline t :background ,uwu-bg :foreground ,uwu-highlight))))
                           `(fill-column-indicator ((,class :foreground ,uwu-highlight :weight semilight)))
                           `(linum ((t (:underline t :foreground ,uwu-highlight))))
                           `(header-line ((t (:foreground ,uwu-yellow


### PR DESCRIPTION
It seems that without explicitly setting a fringe background color, it can sometimes stay the same as the previous or default theme when switching between themes. This change makes the fringe background color explicitly the same as the default background color.