### PR TITLE
Add toggle for disctinct line numbers.

### DIFF
--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -79,6 +79,13 @@
 (defvar uwu-scale-outline-headlines nil
   "Whether `outline-mode' headlines should be scaled.")
 
+(defcustom uwu-distinct-line-numbers t
+  "Make line numbers distinct."
+  :type 'boolean
+  :group 'uwu-theme
+  :package-version '(uwu . "1.0")
+  )
+
 (defcustom uwu-height-minus-1 0.8
   "Font size -1."
   :type 'number
@@ -207,8 +214,12 @@ Also bind `class' to ((class color) (min-colors 89))."
                           `(fringe ((t (:underline t :background ,uwu-bg :foreground ,uwu-highlight))))
                           `(fill-column-indicator ((,class :foreground ,uwu-highlight :weight semilight)))
                           `(linum ((t (:background ,uwu-black :foreground ,uwu-white))))
-                          `(line-number ((t (:background ,uwu-black :foreground ,uwu-white))))
-                          `(line-number-current-line ((t (:inherit line-number :background ,uwu-highlight :foreground ,uwu-bright-white))))
+                          `(line-number ((t (:foreground ,(if uwu-distinct-line-numbers uwu-white uwu-comment)
+                                                         ,@(when uwu-distinct-line-numbers
+                                                             (list :background uwu-black))))))
+                          `(line-number-current-line ((t (:inherit line-number :foreground ,(if uwu-distinct-line-numbers uwu-bright-white uwu-white)
+                                                                   ,@(when uwu-distinct-line-numbers
+                                                                       (list :background uwu-highlight))))))
                           `(header-line ((t (:foreground ,uwu-yellow
                                                          :background ,uwu-black
                                                          :box (:line-width -1 :style released-button)

--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -252,7 +252,6 @@ Also bind `class' to ((class color) (min-colors 89))."
                           `(org-archived ((t (:foreground ,uwu-fg :weight bold))))
                           `(org-block ((t (:background ,uwu-black :foreground ,uwu-white :extend t))))
                           `(org-block-begin-line ((t (:foreground ,uwu-comment :background ,uwu-black :extend t))))
-                          `(org-block-end-line ((t (:foreground ,uwu-comment :background ,uwu-black :extend t))))
                           `(org-code ((t (:foreground ,uwu-bright-yellow ))))
                           `(org-checkbox ((t (:background ,uwu-bg :foreground ,uwu-fg
                                                           :box (:line-width 1 :style released-button)))))

--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -80,11 +80,10 @@
   "Whether `outline-mode' headlines should be scaled.")
 
 (defcustom uwu-distinct-line-numbers t
-  "Make line numbers distinct."
+  "Whether line numbers should look distinct."
   :type 'boolean
   :group 'uwu-theme
-  :package-version '(uwu . "1.0")
-  )
+  :package-version '(uwu . "1.0"))
 
 (defcustom uwu-height-minus-1 0.8
   "Font size -1."


### PR DESCRIPTION
This adds a variable to toggle if the line numbers should be distinct. The non-distinct version, IMO, is less distracting. It looks like this:
![2022_03_24_15-51-26](https://user-images.githubusercontent.com/54214407/159895594-01540336-7c7d-4822-87d7-d5c91a12f812.png)

Edit: I am pretty new to lisp, and this has just been hacked together. I don't know if it's the right way to do it, but it works