### PR TITLE
Add style for helpful-heading

### DIFF
--- a/uwu-theme.el
+++ b/uwu-theme.el
@@ -419,6 +419,8 @@ Also bind `class' to ((class color) (min-colors 89))."
                           `(orderless-match-face-1 ((t (:foreground ,uwu-magenta))))
                           `(orderless-match-face-2 ((t (:foreground ,uwu-blue))))
                           `(orderless-match-face-3 ((t (:foreground ,uwu-yellow))))
+                          ;;;;; helpful
+                          `(helpful-heading ((t (:foreground ,uwu-bright-green :height 1.2))))
                           ;;;;; rainbow-delimiters
                           `(rainbow-delimiters-depth-1-face ((t (:foreground ,uwu-bright-blue))))
                           `(rainbow-delimiters-depth-2-face ((t (:foreground ,uwu-bright-green))))


### PR DESCRIPTION
This adds support for the 'helpful' package.

![2022_03_30_19-42-56](https://user-images.githubusercontent.com/54214407/160855764-76fa2c05-e4a5-4cbc-a4f4-77396b5adc26.png)
